### PR TITLE
Add openai sync agent example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python dependencies
 RUN pip install --no-cache-dir \
     prometheus-client \
-    grpcio-health-checking
+    grpcio-health-checking==1.67.1
 
 # Install Flytekit from GitHub
 RUN pip install --no-cache-dir git+https://github.com/flyteorg/flytekit.git@master
@@ -20,6 +20,9 @@ RUN pip install --no-cache-dir git+https://github.com/flyteorg/flytekit.git@mast
 # Copy and install the bigquery plugin
 COPY flytekit-bigquery /flytekit-bigquery
 RUN pip install --no-cache-dir /flytekit-bigquery
+
+COPY flytekit-openai /flytekit-openai
+RUN pip install --no-cache-dir /flytekit-openai
 
 # Cleanup
 RUN apt-get purge -y build-essential git \

--- a/README.md
+++ b/README.md
@@ -11,20 +11,20 @@ BigQuery's agent registration is triggered [here](https://github.com/Future-Outl
 1. Following the folder structure in this repo, you can build your custom agent.
 2. Build your own custom agent ([learn more](https://docs.flyte.org/en/latest/user_guide/flyte_agents/developing_agents.html))
 
-> In the following command, `localhost:3000` is the Docker registry that ships with the Flyte demo cluster. Use it or replace it with a registry where you have push permissions.
+> In the following command, `localhost:30000` is the Docker registry that ships with the Flyte demo cluster. Use it or replace it with a registry where you have push permissions.
 
 ```bash
-docker buildx build --platform linux/amd64 -t localhost:30000/flyteagent:custom-bigquery -f Dockerfile .
+docker buildx build --platform linux/amd64 -t localhost:30000/flyteagent:custom-agent -f Dockerfile .
 ```
 
 3. Test the image:
 ```bash
-docker run -it localhost:30000/flyteagent:custom-bigquery
+docker run -it localhost:30000/flyteagent:custom-agent
 ```
 
-4. Check the logs (sensor is created by flytekit, bigquery is created by the custom agent)
+4. Check the logs (sensor is created by flytekit, bigquery and openai is created by the custom agent)
 ```
-(dev) future@outlier ~ % docker run -it localhost:30000/flyteagent:custom-bigquery
+(dev) future@outlier ~ % docker run -it localhost:30000/flyteagent:custom-agent
     
 WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
 🚀 Starting the agent service...
@@ -34,6 +34,7 @@ Starting up the server to expose the prometheus metrics...
 ┃ Agent Name     ┃ Support Task Types            ┃ Is Sync ┃
 ┡━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
 │ Sensor         │ sensor (v0)                   │ False   │
+│ ChatGPT Agent  │ chatgpt (v0)                  │ True    │
 │ Bigquery Agent │ bigquery_query_job_task (v0)  │ False   │
 └────────────────┴───────────────────────────────┴─────────┘
 ```

--- a/flytekit-openai/README.md
+++ b/flytekit-openai/README.md
@@ -1,0 +1,47 @@
+# OpenAI Plugins
+
+The plugin currently features ChatGPT and Batch API agents.
+
+To install the plugin, run the following command:
+
+```bash
+pip install flytekitplugins-openai
+```
+
+## ChatGPT
+
+The ChatGPT plugin allows you to run ChatGPT tasks within the Flyte workflow without requiring any code changes.
+
+```python
+from flytekit import task, workflow
+from flytekitplugins.openai import ChatGPTTask, ChatGPTConfig
+
+chatgpt_small_job = ChatGPTTask(
+    name="chatgpt gpt-3.5-turbo",
+    openai_organization="org-NayNG68kGnVXMJ8Ak4PMgQv7",
+    chatgpt_config={
+            "model": "gpt-3.5-turbo",
+            "temperature": 0.7,
+    },
+)
+
+chatgpt_big_job = ChatGPTTask(
+    name="chatgpt gpt-4",
+    openai_organization="org-NayNG68kGnVXMJ8Ak4PMgQv7",
+    chatgpt_config={
+            "model": "gpt-4",
+            "temperature": 0.7,
+    },
+)
+
+
+@workflow
+def wf(message: str) -> str:
+    message = chatgpt_small_job(message=message)
+    message = chatgpt_big_job(message=message)
+    return message
+
+
+if __name__ == "__main__":
+    print(wf(message="hi"))
+```

--- a/flytekit-openai/flytekitplugins/openai/__init__.py
+++ b/flytekit-openai/flytekitplugins/openai/__init__.py
@@ -1,0 +1,16 @@
+"""
+.. currentmodule:: flytekitplugins.openai
+
+.. autosummary::
+   :template: custom.rst
+   :toctree: generated/
+
+   DownloadJSONFilesTask
+   UploadJSONLFileTask
+   OpenAIFileConfig
+   ChatGPTAgent
+   ChatGPTTask
+"""
+
+from .chatgpt.agent import ChatGPTAgent
+from .chatgpt.task import ChatGPTTask

--- a/flytekit-openai/flytekitplugins/openai/chatgpt/agent.py
+++ b/flytekit-openai/flytekitplugins/openai/chatgpt/agent.py
@@ -1,0 +1,53 @@
+import asyncio
+import logging
+from typing import Optional
+
+from flyteidl.core.execution_pb2 import TaskExecution
+
+from flytekit import FlyteContextManager, lazy_module
+from flytekit.core.type_engine import TypeEngine
+from flytekit.extend.backend.base_agent import AgentRegistry, Resource, SyncAgentBase
+from flytekit.extend.backend.utils import get_agent_secret
+from flytekit.models.literals import LiteralMap
+from flytekit.models.task import TaskTemplate
+
+openai = lazy_module("openai")
+
+TIMEOUT_SECONDS = 10
+OPENAI_API_KEY = "FLYTE_OPENAI_API_KEY"
+
+
+class ChatGPTAgent(SyncAgentBase):
+    name = "ChatGPT Agent"
+
+    def __init__(self):
+        super().__init__(task_type_name="chatgpt")
+
+    async def do(
+        self,
+        task_template: TaskTemplate,
+        inputs: Optional[LiteralMap] = None,
+        **kwargs,
+    ) -> Resource:
+        ctx = FlyteContextManager.current_context()
+        input_python_value = TypeEngine.literal_map_to_kwargs(ctx, inputs, {"message": str})
+        message = input_python_value["message"]
+
+        custom = task_template.custom
+        custom["chatgpt_config"]["messages"] = [{"role": "user", "content": message}]
+        client = openai.AsyncOpenAI(
+            organization=custom["openai_organization"],
+            api_key=get_agent_secret(secret_key=OPENAI_API_KEY),
+        )
+
+        logger = logging.getLogger("httpx")
+        logger.setLevel(logging.WARNING)
+
+        completion = await asyncio.wait_for(client.chat.completions.create(**custom["chatgpt_config"]), TIMEOUT_SECONDS)
+        message = completion.choices[0].message.content
+        outputs = {"o0": message}
+
+        return Resource(phase=TaskExecution.SUCCEEDED, outputs=outputs)
+
+
+AgentRegistry.register(ChatGPTAgent())

--- a/flytekit-openai/flytekitplugins/openai/chatgpt/task.py
+++ b/flytekit-openai/flytekitplugins/openai/chatgpt/task.py
@@ -1,0 +1,44 @@
+from typing import Any, Dict, Optional
+
+from flytekit.configuration import SerializationSettings
+from flytekit.core.base_task import PythonTask
+from flytekit.core.interface import Interface
+from flytekit.extend.backend.base_agent import SyncAgentExecutorMixin
+
+
+class ChatGPTTask(SyncAgentExecutorMixin, PythonTask):
+    """
+    This is the simplest form of a ChatGPT Task, you can define the model and the input you want.
+    """
+
+    _TASK_TYPE = "chatgpt"
+
+    def __init__(self, name: str, chatgpt_config: Dict[str, Any], openai_organization: Optional[str] = None, **kwargs):
+        """
+        Args:
+            name: Name of this task, should be unique in the project
+            openai_organization: OpenAI Organization. String can be found here. https://platform.openai.com/docs/api-reference/organization-optional
+            chatgpt_config: ChatGPT job configuration. Config structure can be found here. https://platform.openai.com/docs/api-reference/completions/create
+        """
+
+        if "model" not in chatgpt_config:
+            raise ValueError("The 'model' configuration variable is required in chatgpt_config")
+
+        task_config = {"openai_organization": openai_organization, "chatgpt_config": chatgpt_config}
+
+        inputs = {"message": str}
+        outputs = {"o0": str}
+
+        super().__init__(
+            task_type=self._TASK_TYPE,
+            name=name,
+            task_config=task_config,
+            interface=Interface(inputs=inputs, outputs=outputs),
+            **kwargs,
+        )
+
+    def get_custom(self, settings: SerializationSettings) -> Dict[str, Any]:
+        return {
+            "openai_organization": self.task_config["openai_organization"],
+            "chatgpt_config": self.task_config["chatgpt_config"],
+        }

--- a/flytekit-openai/setup.py
+++ b/flytekit-openai/setup.py
@@ -1,0 +1,40 @@
+from setuptools import setup
+
+PLUGIN_NAME = "openai"
+
+microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
+
+plugin_requires = ["flytekit>1.10.7", "openai>=1.12.0", "flyteidl>=1.11.0"]
+
+__version__ = "0.0.0+develop"
+
+setup(
+    name=microlib_name,
+    version=__version__,
+    author="flyteorg",
+    author_email="admin@flyte.org",
+    description="This package holds the openai plugins for flytekit",
+    namespace_packages=["flytekitplugins"],
+    packages=[
+        f"flytekitplugins.{PLUGIN_NAME}",
+        f"flytekitplugins.{PLUGIN_NAME}.chatgpt",
+    ],
+    install_requires=plugin_requires,
+    license="apache2",
+    python_requires=">=3.9",
+    classifiers=[
+        "Intended Audience :: Science/Research",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        "Topic :: Software Development",
+        "Topic :: Software Development :: Libraries",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+    ],
+    entry_points={"flytekit.plugins": [f"{PLUGIN_NAME}=flytekitplugins.{PLUGIN_NAME}"]},
+)


### PR DESCRIPTION
## Why we need this
We want to provide both async and sync agent templates for users to reference from. Therefore, we provided an openai agent (without batch API) as an example.

## What changes are made
1. Add openai agent example as sync agent template
2. Modify Dockerfile to install openai agent in container
3. Document change

## Screenshots

- Build Image
![image](https://github.com/user-attachments/assets/05b6d98a-93b9-407c-9cce-39f093956336)

- Run Image
![image](https://github.com/user-attachments/assets/a01a85ee-27b7-4945-9b50-1e4a464cf509)
